### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Implementing the Periscope App Pull-to-refresh 
+# Implementing the Periscope App Pull-to-refresh 
 
 This is the code for the **ThinkAndBuild** tutorial that shows how to implement a pull to refresh control similar to the one implemented in [Periscope for iOS](https://itunes.apple.com/it/app/periscope/id972909677?mt=8). 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
